### PR TITLE
fix: maintain legacy mia-agents Citroën bridge

### DIFF
--- a/orchestration/mia-agents/agents/README.md
+++ b/orchestration/mia-agents/agents/README.md
@@ -1,5 +1,7 @@
 # PSA/Citroën Telemetry Agent
 
+> Legacy bridge: Citroën/PSA diagnostics are maintained for compatibility. New MIA automotive development targets the Audi A4 B3 read-only path first.
+
 This agent bridges an ELM327 OBD-II adapter to the Mia system via ZeroMQ. It queries standard and PSA-specific PIDs (like DPF Soot Mass, Eolys Level) and publishes them as FlatBuffers messages.
 
 ## Setup
@@ -12,7 +14,7 @@ This agent bridges an ELM327 OBD-II adapter to the Mia system via ZeroMQ. It que
 
     If they are not installed, you can install them (note: on some systems this requires `--break-system-packages` or using apt):
     ```bash
-    pip install --break-system-packages -r agents/requirements.txt
+    pip install --break-system-packages -r orchestration/mia-agents/agents/requirements.txt
     ```
 
 2.  **FlatBuffers Generation**:
@@ -24,21 +26,23 @@ This agent bridges an ELM327 OBD-II adapter to the Mia system via ZeroMQ. It que
 
 ## Usage
 
-Run the bridge script:
+Run the bridge script from the repository root:
 
 ```bash
 export ELM_SERIAL_PORT=/dev/ttyUSB0
 export ELM_BAUD_RATE=38400
-export ZMQ_PUB_PORT=5555
-python3 agents/citroen_bridge.py
+export ZMQ_PUB_PORT=5556
+python3 orchestration/mia-agents/agents/citroen_bridge.py
 ```
+
+`ZMQ_PUB_PORT` defaults to `5556`, matching the MIA telemetry PUB/SUB path.
 
 ## Mock Mode
 
 For testing without a vehicle/adapter, set `ELM_MOCK=1`:
 
 ```bash
-ELM_MOCK=1 python3 agents/citroen_bridge.py
+ELM_MOCK=1 python3 orchestration/mia-agents/agents/citroen_bridge.py
 ```
 
 This will generate random telemetry data and publish it.
@@ -46,4 +50,4 @@ This will generate random telemetry data and publish it.
 ## Configuration
 
 Commands are defined in `config/commands.json`.
-Decoder logic is in `agents/psa_decoder.py`.
+Decoder logic is in `orchestration/mia-agents/agents/psa_decoder.py`.

--- a/orchestration/mia-agents/agents/citroen_bridge.py
+++ b/orchestration/mia-agents/agents/citroen_bridge.py
@@ -2,13 +2,28 @@ import logging
 import os
 import sys
 import time
-from typing import Callable, Optional
+import importlib.util
+from pathlib import Path
+from typing import Any, Callable, Optional
 
-import serial
-import zmq
+try:
+    import serial
+except ImportError:  # pragma: no cover - exercised in lean CI environments
+    serial = None
 
-# Add project root to sys.path to allow importing 'Mia' package
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+try:
+    import zmq
+except ImportError:  # pragma: no cover - exercised in lean CI environments
+    zmq = None
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+MIA_AGENTS_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ZMQ_PUB_PORT = 5556
+
+for import_root in (PROJECT_ROOT, MIA_AGENTS_ROOT):
+    import_root_str = str(import_root)
+    if import_root_str not in sys.path:
+        sys.path.insert(0, import_root_str)
 
 # Attempt to import generated FlatBuffers classes
 # In a real setup, these would be generated into a known python path
@@ -17,7 +32,24 @@ try:
 except ImportError:
     build_citroen_telemetry = None
 
-from agents import psa_decoder
+
+def _load_local_psa_decoder() -> Any:
+    """Load the sibling PSA decoder without depending on the ambiguous root agents package."""
+    decoder_path = Path(__file__).with_name("psa_decoder.py")
+    spec = importlib.util.spec_from_file_location("mia_agents_psa_decoder", decoder_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load PSA decoder from {decoder_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+try:
+    from . import psa_decoder
+except ImportError:
+    psa_decoder = _load_local_psa_decoder()
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +59,7 @@ def parse_hex_val(resp: str, prefix: str = '41') -> str:
     clean = resp.replace(" ", "").replace(">", "").strip()
     if prefix and prefix in clean:
         idx = clean.find(prefix)
-        return clean[idx + 4:]
+        return clean[idx + len(prefix):]
     return clean
 
 
@@ -53,7 +85,8 @@ def decode_hex_measurement(
         )
         return 0.0
 
-def main():
+
+def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s - %(levelname)s - %(message)s'
@@ -62,7 +95,14 @@ def main():
     # Configuration
     serial_port = os.environ.get('ELM_SERIAL_PORT', '/dev/ttyUSB0')
     baud_rate = int(os.environ.get('ELM_BAUD_RATE', 38400))
-    zmq_pub_port = int(os.environ.get('ZMQ_PUB_PORT', 5557))
+    zmq_pub_port = int(os.environ.get('ZMQ_PUB_PORT', DEFAULT_ZMQ_PUB_PORT))
+
+    if zmq is None:
+        logging.error(
+            "pyzmq is required to publish telemetry; install "
+            "orchestration/mia-agents/agents/requirements.txt"
+        )
+        return
 
     # Setup ZMQ
     context = zmq.Context()
@@ -71,10 +111,17 @@ def main():
     logging.info(f"ZMQ Publisher bound to tcp://*:{zmq_pub_port}")
 
     # Setup Serial
-    ser: Optional[serial.Serial] = None
+    ser: Optional[Any] = None
     if os.environ.get('ELM_MOCK', '0') == '1':
         logging.info("Starting in MOCK mode")
     else:
+        if serial is None:
+            logging.error(
+                "pyserial is required unless ELM_MOCK=1; install "
+                "orchestration/mia-agents/agents/requirements.txt"
+            )
+            return
+
         try:
             ser = serial.Serial(serial_port, baud_rate, timeout=1)
             logging.info(f"Connected to {serial_port} at {baud_rate} baud")

--- a/tests/test_psa_decoder.py
+++ b/tests/test_psa_decoder.py
@@ -1,11 +1,27 @@
 import unittest
+import importlib.util
 import sys
-import os
+from pathlib import Path
 
-# Add project root to sys.path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from agents import psa_decoder
+def load_psa_decoder_module():
+    """Import the legacy PSA decoder from its current mia-agents location."""
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "orchestration"
+        / "mia-agents"
+        / "agents"
+        / "psa_decoder.py"
+    )
+    spec = importlib.util.spec_from_file_location("mia_agents_psa_decoder", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+psa_decoder = load_psa_decoder_module()
 
 
 class TestPsaDecoder(unittest.TestCase):

--- a/tests/unit/test_citroen_bridge_script.py
+++ b/tests/unit/test_citroen_bridge_script.py
@@ -25,6 +25,21 @@ def test_decode_hex_measurement_parses_valid_payload():
     assert rpm == 2000.0
 
 
+def test_parse_hex_val_strips_variable_length_prefix():
+    """The low-level parser should strip the exact prefix length, not a fixed byte count."""
+    module = load_citroen_bridge_module()
+
+    assert module.parse_hex_val("41 0D 3C", "41") == "0D3C"
+    assert module.parse_hex_val("41 0D 3C", "410D") == "3C"
+
+
+def test_default_zmq_pub_port_matches_telemetry_pubsub():
+    """Legacy bridge should publish on the canonical telemetry PUB/SUB port by default."""
+    module = load_citroen_bridge_module()
+
+    assert module.DEFAULT_ZMQ_PUB_PORT == 5556
+
+
 def test_decode_hex_measurement_returns_zero_on_invalid_hex(caplog):
     """Malformed payloads should return the existing zero default and emit a warning."""
     module = load_citroen_bridge_module()


### PR DESCRIPTION
## Summary

- make the legacy `orchestration/mia-agents` Citroën bridge importable from the repo root and from direct script/test execution
- avoid ambiguous `agents` package resolution by loading the sibling PSA decoder explicitly
- align the bridge default telemetry PUB/SUB port and docs to `5556`
- fix the stale PSA decoder test import and add coverage for prefix parsing/default port behavior
- document that the Citroën/PSA bridge is legacy while new automotive work targets the Audi A4 B3 read-only path

## Validation

- `python -m compileall -q orchestration/mia-agents tests/test_psa_decoder.py tests/test_citroen_bridge.py tests/unit/test_citroen_bridge_script.py`
- `python -m unittest tests.test_psa_decoder tests.test_citroen_bridge -v`
- `python -m pytest tests/test_psa_decoder.py tests/test_citroen_bridge.py tests/unit/test_citroen_bridge_script.py -q` → 15 passed

## Notes

Local direct `git push` hung in this environment, so the branch was created and updated on the fork through the GitHub API.