### PR TITLE
feat(mia): wire claudepy bridge into core orchestrator

### DIFF
--- a/orchestration/mcp/modules/claudepy-bridge/__init__.py
+++ b/orchestration/mcp/modules/claudepy-bridge/__init__.py
@@ -1,0 +1,9 @@
+"""
+Claudepy Bridge Module for MIA
+
+Provides integration between MIA's voice pipeline and claudepy's AI orchestrator.
+"""
+
+from .mia_claudepy_bridge import ClaudepyBridge, InMemoryVoiceRAG, VoiceCommandResult
+
+__all__ = ["ClaudepyBridge", "InMemoryVoiceRAG", "VoiceCommandResult"]

--- a/orchestration/mcp/modules/claudepy-bridge/main.py
+++ b/orchestration/mcp/modules/claudepy-bridge/main.py
@@ -1,0 +1,5 @@
+"""Compatibility entry point for the MIA claudepy bridge."""
+
+from .mia_claudepy_bridge import ClaudepyBridge, InMemoryVoiceRAG, VoiceCommandResult
+
+__all__ = ["ClaudepyBridge", "InMemoryVoiceRAG", "VoiceCommandResult"]

--- a/orchestration/mcp/modules/claudepy-bridge/mia_claudepy_bridge.py
+++ b/orchestration/mcp/modules/claudepy-bridge/mia_claudepy_bridge.py
@@ -1,0 +1,299 @@
+"""Claudepy bridge for MIA voice-command orchestration.
+
+This module is intentionally import-light at module load time.  The real
+claudepy objects are imported lazily in :meth:`ClaudepyBridge.initialize` so
+MIA can still start in environments where the AI backend is not installed.
+
+Routing a MIA voice path through this bridge
+--------------------------------------------
+The live voice entry point is
+``orchestration/mcp/modules/core-orchestrator/enhanced_orchestrator.py``,
+in ``EnhancedOrchestrator.handle_enhanced_voice_command(text, ...)``, which
+today parses intent with a keyword NLP and dispatches via
+``_route_enhanced_command(intent_result, session_context, context)``.
+
+To route that path through claudepy (follow-up PR — core-orchestrator is
+deliberately NOT modified here), ``_route_enhanced_command`` (or the
+``question_answer`` / low-confidence branch of ``handle_enhanced_voice_command``)
+would delegate to::
+
+    result = await self.claudepy_bridge.process_voice_command(
+        text,
+        context={"session_id": session_id, "intent": intent_result.intent,
+                 **(context or {})},
+    )
+    response = result.response
+
+``ClaudepyBridge`` degrades to a keyword fallback when claudepy is unavailable,
+so the orchestrator keeps working even without the AI backend installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PROMPTS_SERVER = (
+    Path.home()
+    / "projects/mcp/ai-mcp-monorepo/packages/mcp-prompts/dist/mcp-server-standalone.js"
+)
+_DEFAULT_PROMPTS_DIR = Path.home() / "projects/mcp/ai-mcp-monorepo/packages/mcp-prompts/data"
+
+
+class _AsyncPromptClient(Protocol):
+    async def call_tool(self, name: str, arguments: Dict[str, Any]) -> Any: ...
+
+    async def __aenter__(self) -> "_AsyncPromptClient": ...
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None: ...
+
+
+@dataclass
+class VoiceCommandResult:
+    """Structured result returned to MIA's voice pipeline."""
+
+    response: str
+    provider_used: str
+    latency_ms: float
+    tokens_used: int = 0
+    rag_context: List[str] = field(default_factory=list)
+    intent: Optional[str] = None
+    error: Optional[str] = None
+
+
+class InMemoryVoiceRAG:
+    """Tiny in-memory retriever for recent voice command context.
+
+    H1 only needs a reversible bridge with tests; persistent ChromaDB can be
+    swapped in later without changing the bridge API.
+    """
+
+    def __init__(self, max_items: int = 100) -> None:
+        self.max_items = max_items
+        self._items: List[Dict[str, str]] = []
+
+    async def add_interaction(self, command: str, response: str) -> None:
+        self._items.append({"command": command, "response": response})
+        if len(self._items) > self.max_items:
+            self._items = self._items[-self.max_items :]
+
+    async def retrieve(self, command: str, limit: int = 3) -> List[str]:
+        terms = {token for token in command.lower().split() if len(token) > 2}
+        scored: List[tuple[int, Dict[str, str]]] = []
+        for item in self._items:
+            haystack = f"{item['command']} {item['response']}".lower()
+            score = sum(1 for term in terms if term in haystack)
+            if score:
+                scored.append((score, item))
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [f"Q: {item['command']}\nA: {item['response']}" for _, item in scored[:limit]]
+
+
+class ClaudepyBridge:
+    """Route MIA voice commands through claudepy with safe fallback behavior."""
+
+    def __init__(
+        self,
+        *,
+        default_provider: str = "kimi",
+        prompts_server: Path | str = _DEFAULT_PROMPTS_SERVER,
+        prompts_dir: Path | str = _DEFAULT_PROMPTS_DIR,
+        rag: Optional[InMemoryVoiceRAG] = None,
+        orchestrator: Optional[Any] = None,
+        mcp_prompts: Optional[_AsyncPromptClient] = None,
+    ) -> None:
+        self.default_provider = default_provider
+        self.prompts_server = Path(prompts_server)
+        self.prompts_dir = Path(prompts_dir)
+        self.rag = rag or InMemoryVoiceRAG()
+        self._orchestrator = orchestrator
+        self._mcp_prompts = mcp_prompts
+        self._owns_mcp_client = False
+        self._initialized = orchestrator is not None
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    async def initialize(self) -> None:
+        """Initialize claudepy provider/orchestrator and mcp-prompts client."""
+
+        if self._initialized:
+            return
+
+        try:
+            from claudepy.agents import Orchestrator
+            from claudepy.mcp import McpClient
+            from claudepy.providers import ProviderRegistry, ProviderType
+            from claudepy.types import McpServerConfig, TransportKind
+        except ImportError as exc:
+            logger.warning("claudepy unavailable; using fallback voice processing: %s", exc)
+            self._initialized = False
+            return
+
+        provider_type = getattr(ProviderType, self.default_provider.upper(), ProviderType.ANTHROPIC)
+        provider = ProviderRegistry.create(provider_type)
+        self._orchestrator = Orchestrator(provider)
+
+        if self._mcp_prompts is None:
+            config = McpServerConfig(
+                transport=TransportKind.STDIO,
+                command="node",
+                args=[str(self.prompts_server)],
+                env={"PROMPTS_DIR": str(self.prompts_dir)},
+            )
+            self._mcp_prompts = McpClient(config)
+            await self._mcp_prompts.__aenter__()
+            self._owns_mcp_client = True
+
+        self._initialized = True
+
+    async def process_voice_command(
+        self,
+        text: str,
+        context: Optional[Dict[str, Any]] = None,
+        *,
+        use_rag: bool = True,
+        use_prompts: bool = True,
+    ) -> VoiceCommandResult:
+        """Process a transcribed voice command and return a structured result."""
+
+        started = time.perf_counter()
+        context = context or {}
+        clean_text = text.strip()
+        if not clean_text:
+            return VoiceCommandResult(
+                response="I did not catch a command.",
+                provider_used="fallback",
+                latency_ms=self._elapsed_ms(started),
+                intent="unknown",
+            )
+
+        await self.initialize()
+        if not self._initialized or self._orchestrator is None:
+            return await self._fallback_process(clean_text, context, started)
+
+        try:
+            prompt = await self._voice_system_prompt(use_prompts)
+            rag_context = await self.rag.retrieve(clean_text) if use_rag else []
+            task = self._build_task(clean_text, context, prompt, rag_context)
+            raw_response = await self._run_orchestrator(task)
+            response_text = self._extract_response_text(raw_response)
+            await self.rag.add_interaction(clean_text, response_text)
+            return VoiceCommandResult(
+                response=response_text,
+                provider_used=self.default_provider,
+                latency_ms=self._elapsed_ms(started),
+                tokens_used=self._extract_tokens(raw_response),
+                rag_context=rag_context,
+                intent=self._infer_intent(clean_text),
+            )
+        except Exception as exc:
+            logger.exception("claudepy voice processing failed; falling back")
+            result = await self._fallback_process(clean_text, context, started)
+            result.error = str(exc)
+            return result
+
+    async def close(self) -> None:
+        if self._owns_mcp_client and self._mcp_prompts is not None:
+            await self._mcp_prompts.__aexit__(None, None, None)
+        self._initialized = False
+
+    async def _voice_system_prompt(self, use_prompts: bool) -> str:
+        default = "You are MIA, a concise voice assistant. Interpret the user command and answer with the action to take."
+        if not use_prompts or self._mcp_prompts is None:
+            return default
+        try:
+            result = await self._mcp_prompts.call_tool(
+                "get_prompt", {"id": "voice-command-design-principles"}
+            )
+        except Exception as exc:
+            logger.debug("mcp-prompts lookup failed: %s", exc)
+            return default
+        if isinstance(result, dict):
+            return str(result.get("content") or result.get("prompt") or default)
+        return default
+
+    def _build_task(
+        self,
+        text: str,
+        context: Dict[str, Any],
+        system_prompt: str,
+        rag_context: List[str],
+    ) -> str:
+        parts = [system_prompt, f"Voice command: {text}"]
+        if context:
+            parts.append(f"Runtime context: {context}")
+        if rag_context:
+            parts.append("Relevant past voice interactions:\n" + "\n---\n".join(rag_context))
+        return "\n\n".join(parts)
+
+    async def _run_orchestrator(self, task: str) -> Any:
+        # The real claudepy Orchestrator exposes execute(task, sub_tasks=None);
+        # prefer it so the bridge actually reaches claudepy in production. run()/
+        # generate() are kept as forward-compatible fallbacks for alternate shims.
+        if hasattr(self._orchestrator, "execute"):
+            return await self._orchestrator.execute(task)
+        if hasattr(self._orchestrator, "run"):
+            return await self._orchestrator.run(task=task, provider_type=None)
+        if hasattr(self._orchestrator, "generate"):
+            return await self._orchestrator.generate(task)
+        raise RuntimeError("Unsupported claudepy orchestrator interface")
+
+    async def _fallback_process(
+        self, text: str, context: Dict[str, Any], started: float
+    ) -> VoiceCommandResult:
+        intent = self._infer_intent(text)
+        response_by_intent = {
+            "smart_home": "I can route that smart-home command.",
+            "communication": "I can route that message command.",
+            "navigation": "I can route that navigation command.",
+            "question_answer": "I can answer that once the AI backend is available.",
+        }
+        response = response_by_intent.get(intent, f"I heard: {text}")
+        await self.rag.add_interaction(text, response)
+        return VoiceCommandResult(
+            response=response,
+            provider_used="fallback",
+            latency_ms=self._elapsed_ms(started),
+            intent=intent,
+        )
+
+    def _infer_intent(self, text: str) -> str:
+        lowered = text.lower()
+        if any(word in lowered for word in ("light", "thermostat", "temperature", "home")):
+            return "smart_home"
+        if any(word in lowered for word in ("send", "message", "call", "telegram", "whatsapp")):
+            return "communication"
+        if any(word in lowered for word in ("navigate", "route", "map", "where")):
+            return "navigation"
+        if lowered.startswith(("what", "how", "why", "when", "who")):
+            return "question_answer"
+        return "unknown"
+
+    def _extract_response_text(self, response: Any) -> str:
+        if isinstance(response, str):
+            return response
+        if hasattr(response, "content"):
+            return str(response.content)
+        if isinstance(response, dict):
+            return str(response.get("content") or response.get("response") or response)
+        return str(response)
+
+    def _extract_tokens(self, response: Any) -> int:
+        usage = getattr(response, "usage", None)
+        if usage is not None and hasattr(usage, "total_tokens"):
+            return int(usage.total_tokens)
+        if isinstance(response, dict):
+            usage_dict = response.get("usage") or {}
+            if isinstance(usage_dict, dict):
+                return int(usage_dict.get("total_tokens", 0) or 0)
+        return 0
+
+    def _elapsed_ms(self, started: float) -> float:
+        return (time.perf_counter() - started) * 1000

--- a/orchestration/mcp/modules/core-orchestrator/enhanced_orchestrator.py
+++ b/orchestration/mcp/modules/core-orchestrator/enhanced_orchestrator.py
@@ -1347,6 +1347,95 @@ class EnhancedCoreOrchestrator(MCPServer):
                 logger.warning(f"Health check failed for {service_name}: {e}")
 
 
+# --- Claudepy bridge wire-up -------------------------------------------------
+# Kept as an import-light shim because the bridge module lives in the existing
+# hyphenated MCP module directory (``claudepy-bridge``) and claudepy is optional
+# on Raspberry Pi / CI images. The bridge itself falls back when claudepy is not
+# installed, so routing low-confidence voice commands through it is safe.
+
+def _load_claudepy_bridge_class():
+    import importlib.util
+    import sys
+
+    bridge_path = Path(__file__).resolve().parents[1] / "claudepy-bridge" / "mia_claudepy_bridge.py"
+    spec = importlib.util.spec_from_file_location("mia_claudepy_bridge", bridge_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load claudepy bridge from {bridge_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("mia_claudepy_bridge", module)
+    spec.loader.exec_module(module)
+    return module.ClaudepyBridge
+
+
+def _ensure_claudepy_bridge(orchestrator):
+    bridge = getattr(orchestrator, "claudepy_bridge", None)
+    if bridge is None:
+        bridge_cls = _load_claudepy_bridge_class()
+        bridge = bridge_cls()
+        orchestrator.claudepy_bridge = bridge
+    return bridge
+
+
+def _should_route_via_claudepy(result, context):
+    if context and context.get("force_claudepy"):
+        return True
+    if not isinstance(result, dict):
+        return False
+    intent = result.get("intent")
+    confidence = float(result.get("confidence") or 0.0)
+    threshold = float(os.getenv("MIA_CLAUDEPY_BRIDGE_CONFIDENCE_THRESHOLD", "0.25"))
+    return intent in {"unknown", "question_answer"} or confidence < threshold
+
+
+_ORIGINAL_HANDLE_ENHANCED_VOICE_COMMAND = EnhancedCoreOrchestrator.handle_enhanced_voice_command
+
+
+async def _handle_enhanced_voice_command_with_claudepy(
+    self,
+    text: str,
+    session_id: Optional[str] = None,
+    user_id: str = "default",
+    interface_type: str = "voice",
+    context: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    result = await _ORIGINAL_HANDLE_ENHANCED_VOICE_COMMAND(
+        self,
+        text=text,
+        session_id=session_id,
+        user_id=user_id,
+        interface_type=interface_type,
+        context=context,
+    )
+    if not _should_route_via_claudepy(result, context or {}):
+        return result
+
+    bridge = _ensure_claudepy_bridge(self)
+    bridge_result = await bridge.process_voice_command(
+        text,
+        context={
+            "session_id": session_id,
+            "user_id": user_id,
+            "interface_type": interface_type,
+            **(context or {}),
+        },
+    )
+    enriched = dict(result) if isinstance(result, dict) else {"response": str(result)}
+    enriched.update(
+        {
+            "response": bridge_result.response,
+            "provider_used": bridge_result.provider_used,
+            "bridge_latency_ms": bridge_result.latency_ms,
+            "bridge_rag_context": bridge_result.rag_context,
+            "bridge_error": bridge_result.error,
+        }
+    )
+    return enriched
+
+
+EnhancedCoreOrchestrator.handle_enhanced_voice_command = _handle_enhanced_voice_command_with_claudepy
+# --- end Claudepy bridge wire-up --------------------------------------------
+
+
 async def main():
     """Main entry point for enhanced orchestrator"""
     logger.info("Starting MIA Enhanced Core Orchestrator")

--- a/tests/test_mia_claudepy_bridge.py
+++ b/tests/test_mia_claudepy_bridge.py
@@ -205,7 +205,10 @@ def load_enhanced_orchestrator_module():
 @pytest.mark.asyncio
 async def test_enhanced_orchestrator_force_routes_voice_command_through_bridge(tmp_path, monkeypatch):
     module = load_enhanced_orchestrator_module()
-    orchestrator = module.EnhancedCoreOrchestrator(data_dir=str(tmp_path))
+    # EnhancedCoreOrchestrator.__init__ takes no args; per-instance state lives
+    # on its ContextManager (which does accept data_dir). tmp_path is retained
+    # in the signature for future fixtures that persist analytics/context to disk.
+    orchestrator = module.EnhancedCoreOrchestrator()
     bridge = FakeBridge()
     orchestrator.claudepy_bridge = bridge
 

--- a/tests/test_mia_claudepy_bridge.py
+++ b/tests/test_mia_claudepy_bridge.py
@@ -1,0 +1,226 @@
+"""Tests for the MIA claudepy bridge.
+
+The bridge directory is hyphenated, so tests load it by path just like the
+existing core-orchestrator harness.
+"""
+
+import importlib.util
+import os
+import sys
+from dataclasses import dataclass
+
+import pytest
+
+_BRIDGE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "orchestration",
+    "mcp",
+    "modules",
+    "claudepy-bridge",
+    "mia_claudepy_bridge.py",
+)
+_spec = importlib.util.spec_from_file_location("mia_claudepy_bridge", _BRIDGE_PATH)
+_bridge_module = importlib.util.module_from_spec(_spec)
+sys.modules["mia_claudepy_bridge"] = _bridge_module
+assert _spec.loader is not None
+_spec.loader.exec_module(_bridge_module)
+
+ClaudepyBridge = _bridge_module.ClaudepyBridge
+InMemoryVoiceRAG = _bridge_module.InMemoryVoiceRAG
+VoiceCommandResult = _bridge_module.VoiceCommandResult
+
+
+class FakePromptClient:
+    def __init__(self):
+        self.calls = []
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return {"content": "Use concise MIA voice responses."}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+@dataclass
+class FakeUsage:
+    total_tokens: int = 42
+
+
+@dataclass
+class FakeResponse:
+    content: str
+    usage: FakeUsage
+
+
+class FakeOrchestrator:
+    def __init__(self):
+        self.tasks = []
+
+    async def run(self, task, provider_type=None):
+        self.tasks.append(task)
+        return FakeResponse(content="Turning on the office lights.", usage=FakeUsage())
+
+
+class FakeExecuteOrchestrator:
+    """Mirrors the real ``claudepy.agents.Orchestrator`` surface: ``execute(task)``.
+
+    ``FakeOrchestrator`` above exercises a ``run(...)`` method that the real
+    claudepy Orchestrator does not expose. This fake guards against the bridge
+    only ever working against an imagined API and silently falling back once it
+    is wired to the real orchestrator in production.
+    """
+
+    def __init__(self):
+        self.tasks = []
+
+    async def execute(self, task, sub_tasks=None):
+        self.tasks.append(task)
+        return FakeResponse(content="Navigating to the office.", usage=FakeUsage(total_tokens=7))
+
+
+@pytest.mark.unit
+class TestInMemoryVoiceRAG:
+    @pytest.mark.asyncio
+    async def test_retrieves_similar_interactions(self):
+        rag = InMemoryVoiceRAG()
+        await rag.add_interaction("turn on office lights", "Office lights are on.")
+        await rag.add_interaction("play music", "Playing music.")
+
+        context = await rag.retrieve("office lights please")
+
+        assert len(context) == 1
+        assert "office lights" in context[0]
+
+
+@pytest.mark.unit
+class TestClaudepyBridge:
+    @pytest.mark.asyncio
+    async def test_bridge_construction_defaults_to_uninitialized(self):
+        bridge = ClaudepyBridge()
+
+        assert bridge.default_provider == "kimi"
+        assert bridge.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_voice_command_round_trip_with_injected_orchestrator(self):
+        orchestrator = FakeOrchestrator()
+        prompt_client = FakePromptClient()
+        rag = InMemoryVoiceRAG()
+        await rag.add_interaction("turn on kitchen lights", "Kitchen lights are on.")
+        bridge = ClaudepyBridge(
+            orchestrator=orchestrator,
+            mcp_prompts=prompt_client,
+            rag=rag,
+        )
+
+        result = await bridge.process_voice_command(
+            "turn on office lights",
+            {"session_id": "s1", "location": "office"},
+        )
+
+        assert isinstance(result, VoiceCommandResult)
+        assert result.response == "Turning on the office lights."
+        assert result.provider_used == "kimi"
+        assert result.tokens_used == 42
+        assert result.intent == "smart_home"
+        assert prompt_client.calls == [("get_prompt", {"id": "voice-command-design-principles"})]
+        assert "Voice command: turn on office lights" in orchestrator.tasks[0]
+        assert "Runtime context" in orchestrator.tasks[0]
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_claudepy_is_unavailable(self):
+        bridge = ClaudepyBridge()
+
+        result = await bridge.process_voice_command("send a telegram message", use_prompts=False)
+
+        assert result.provider_used == "fallback"
+        assert result.intent == "communication"
+        assert "message" in result.response.lower()
+
+    @pytest.mark.asyncio
+    async def test_voice_command_routes_through_real_execute_interface(self):
+        # Regression guard: the real claudepy Orchestrator exposes execute(),
+        # not run()/generate(). If the bridge cannot drive execute(), it silently
+        # falls back and never actually reaches claudepy in production.
+        orchestrator = FakeExecuteOrchestrator()
+        bridge = ClaudepyBridge(orchestrator=orchestrator, mcp_prompts=FakePromptClient())
+
+        result = await bridge.process_voice_command("navigate to the office")
+
+        assert result.provider_used == "kimi"  # not "fallback"
+        assert result.response == "Navigating to the office."
+        assert result.tokens_used == 7
+        assert orchestrator.tasks, "orchestrator.execute() was never called"
+        assert "Voice command: navigate to the office" in orchestrator.tasks[0]
+
+    def test_real_claudepy_orchestrator_exposes_execute(self):
+        # Ties the FakeExecuteOrchestrator contract to the real API. Skips when
+        # claudepy is not installed in this environment.
+        pytest.importorskip("claudepy.agents")
+        from claudepy.agents import Orchestrator
+
+        assert hasattr(Orchestrator, "execute")
+
+
+
+class FakeBridgeResult:
+    response = "Routed through claudepy bridge."
+    provider_used = "fake-claudepy"
+    latency_ms = 3.5
+    rag_context = ["Q: previous\nA: answer"]
+    error = None
+
+
+class FakeBridge:
+    def __init__(self):
+        self.calls = []
+
+    async def process_voice_command(self, text, context=None, **kwargs):
+        self.calls.append((text, context or {}, kwargs))
+        return FakeBridgeResult()
+
+
+def load_enhanced_orchestrator_module():
+    import importlib.util
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "orchestration/mcp/modules/core-orchestrator/enhanced_orchestrator.py"
+    sys.path.insert(0, str(repo_root))
+    module_name = "orchestration.mcp.modules.core_orchestrator.enhanced_orchestrator"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_enhanced_orchestrator_force_routes_voice_command_through_bridge(tmp_path, monkeypatch):
+    module = load_enhanced_orchestrator_module()
+    orchestrator = module.EnhancedCoreOrchestrator(data_dir=str(tmp_path))
+    bridge = FakeBridge()
+    orchestrator.claudepy_bridge = bridge
+
+    result = await orchestrator.handle_enhanced_voice_command(
+        text="what can you do for me?",
+        session_id="s-bridge",
+        user_id="u-bridge",
+        interface_type="voice",
+        context={"force_claudepy": True},
+    )
+
+    assert result["response"] == "Routed through claudepy bridge."
+    assert result["provider_used"] == "fake-claudepy"
+    assert result["bridge_rag_context"] == ["Q: previous\nA: answer"]
+    assert bridge.calls
+    assert bridge.calls[0][0] == "what can you do for me?"
+    assert bridge.calls[0][1]["session_id"] == "s-bridge"
+    assert bridge.calls[0][1]["force_claudepy"] is True


### PR DESCRIPTION
## Summary
- Carry forward the claudepy bridge module from the H1 implementation onto current main
- Route forced/low-confidence enhanced voice commands through ClaudepyBridge.process_voice_command()
- Add regression coverage proving the enhanced core-orchestrator path reaches the bridge

## Tests
- python -m pytest tests/test_mia_claudepy_bridge.py -q

Triangle backlog: H11